### PR TITLE
fix: improve agent detection heuristics

### DIFF
--- a/heuristic.py
+++ b/heuristic.py
@@ -148,7 +148,10 @@ def from_json(obj: Any) -> Heuristic:
     files = tuple(obj["files"])
     branch_name_prefix = tuple(obj["branch_name_prefix"])
     commit_message_prefix = tuple(obj["commit_message_prefix"])
-    period_start = datetime.now()  # datetime.fromisoformat(obj["period_start"])
+    try:
+        period_start = datetime.fromisoformat(obj["period_start"])
+    except (ValueError, KeyError):
+        period_start = datetime.min  # treat missing/empty as "active from the beginning"
     period_end = None
     if not (obj["period_end"] is None or obj["period_end"] in ["None", "null"]):
         period_end = datetime.fromisoformat(obj["period_end"])


### PR DESCRIPTION
working with @tdegueul at Bellairs.

Found and fixed this bug.

```
# BEFORE
$ python script/detect-agents.py data/steipete-2025-12.json
Commits: 2908  |  with file cache: 1802  |  agents loaded: 44

Agent Detection — steipete-2025-12
=======================================================
  Commits with ≥1 agent signal : 65 / 2908  (2%)
  Commits with >1 agent signal : 6

Agents detected  (n=2908 commits)
─────────────────────────────────
  codex                     █████████████████████████████████████ 2%         54
  amp                       ███████ 0%                                       13
  claude_code               ██ 0%                                             3
  gemini                    █ 0%                                              1

# AFTER
$ python script/detect-agents.py data/steipete-2025-12.json
Commits: 2908  |  cached: 2808  |  full message: 0  |  agents: 44
  tip: run analyze-commit-quality.py first to fetch full messages

Agent Detection — steipete-2025-12
=======================================================
  Commits with ≥1 agent signal : 102 / 2908  (4%)
  Commits with >1 agent signal : 6

Agents detected  (n=2908 commits)
─────────────────────────────────
  codex                     █████████████████████████████████████ 3%         78
  amp                       ██████████ 1%                                    26
  claude_code               ██ 0%                                             3
  gemini                    █ 0%                                              1
```

really unclear why it's really hard to identify the agents used in @steipete commits. He probably prompts to remove the default commits/branches idiosyncrasies. 